### PR TITLE
adding fallback option

### DIFF
--- a/clipboard-tool.js
+++ b/clipboard-tool.js
@@ -10,11 +10,14 @@ if (isBrowser) {
 	});
 }
 
-export function write(text) {
+export function write(text, fallbackToPrompt) {
 	if (isBrowser) {
 		clipboardText = text;
 		var success = document.execCommand('copy');
 		if (!success) {
+			if (fallbackToPrompt) {
+				window.prompt('Copy to clipboard using Ctrl/Cmd+C', clipboardText);
+			}
 			console.warn(prefix + "Couldn't copy because the browser doesn't allow it.");
 		}
 	} else {


### PR DESCRIPTION
If the user wants a fallback option, they can now do:

```
clipboard.write('mytext', true);
```

Otherwise it would work the same as before.

Thoughts?
